### PR TITLE
AMD GPU enablement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ build/
 *.egg-info
 
 .vscode/
+
+*.hip
+*.so
+venv/

--- a/fused_bilagrid/uniform_sample_backward_v1.cu
+++ b/fused_bilagrid/uniform_sample_backward_v1.cu
@@ -1,9 +1,6 @@
 #include "config.h"
 
 #include <cooperative_groups.h>
-#include <cooperative_groups/reduce.h>
-
-namespace cg = cooperative_groups;
 
 
 __global__ void bilagrid_uniform_sample_backward_v1_kernel_bilagrid(

--- a/setup.py
+++ b/setup.py
@@ -19,33 +19,34 @@ fallback_archs = [
     "-gencode=arch=compute_80,code=sm_80",
     "-gencode=arch=compute_89,code=sm_89",
 ]
-
-nvcc_args = [
-    "-O3",
-    #"--maxrregcount=32",
-    "--use_fast_math",
-]
-
+nvcc_args = ["-O3"]
 detected_arch = None
 
 if torch.cuda.is_available():
-    try:
-        device = torch.cuda.current_device()
-        compute_capability = torch.cuda.get_device_capability(device)
-        arch = f"sm_{compute_capability[0]}{compute_capability[1]}"
-        
-        # Print to multiple outputs
-        arch_msg = f"Detected GPU architecture: {arch}"
-        print(arch_msg)
-        print(arch_msg, file=sys.stderr, flush=True)
-        
-        nvcc_args.append(f"-arch={arch}")
-        detected_arch = arch
-    except Exception as e:
-        error_msg = f"Failed to detect GPU architecture: {e}. Falling back to multiple architectures."
-        print(error_msg)
-        print(error_msg, file=sys.stderr, flush=True)
-        nvcc_args.extend(fallback_archs)
+    if torch.version.hip:
+        nvcc_args.append("-ffast-math")
+    else:
+        nvcc_args.extend((
+            # "--maxrregcount=32",
+            "--use_fast_math",
+        ))
+        try:
+            device = torch.cuda.current_device()
+            compute_capability = torch.cuda.get_device_capability(device)
+            arch = f"sm_{compute_capability[0]}{compute_capability[1]}"
+
+            # Print to multiple outputs
+            arch_msg = f"Detected GPU architecture: {arch}"
+            print(arch_msg)
+            print(arch_msg, file=sys.stderr, flush=True)
+
+            nvcc_args.append(f"-arch={arch}")
+            detected_arch = arch
+        except Exception as e:
+            error_msg = f"Failed to detect GPU architecture: {e}. Falling back to multiple architectures."
+            print(error_msg)
+            print(error_msg, file=sys.stderr, flush=True)
+            nvcc_args.extend(fallback_archs)
 else:
     cuda_msg = "CUDA not available. Falling back to multiple architectures."
     print(cuda_msg)

--- a/tests/plot.py
+++ b/tests/plot.py
@@ -2,11 +2,13 @@ import matplotlib.pyplot as plt
 import matplotlib
 import numpy as np
 
+import torch
 import json
 import os
 
 save_dir = os.path.join(os.path.dirname(__file__), 'assets')
 os.makedirs(save_dir, exist_ok=True)
+gpu = torch.cuda.get_device_name()
 
 
 def plot_bars(title, timings):
@@ -53,16 +55,14 @@ def plot_bars(title, timings):
     plt.tight_layout()
     # plt.show()
 
+    title = f"{title.replace(' ', '_')}-{gpu.lower().replace(' ', '-')}.png"
     save_path = os.path.join(save_dir, title.replace(' ', '_')+'.png')
     plt.savefig(save_path)
 
 
 if __name__ == "__main__":
-
     with open(os.path.join(os.path.dirname(__file__), "timings.json"), 'r') as fp:
         data = json.load(fp)
 
-    
     for title, timings in data.items():
-
         plot_bars(title, timings)


### PR DESCRIPTION
Part of AMD GPU gsplat enablement.
- Set respective NVCC/HIPCC flags depending on GPU vendor.
- Remove `<cooperative_groups/reduce.h>` as it is not used and not supported by AMD GPU.
  In case we need it in future, for AMD GPU we can simply write our own version of CG reduce.